### PR TITLE
Revert to normal wrap of inline code (issue #16)

### DIFF
--- a/_sass/_github-markdown.scss
+++ b/_sass/_github-markdown.scss
@@ -473,6 +473,7 @@
   padding-bottom: 0.2em;
   margin: 0;
   font-size: 85%;
+  white-space: unset;  /* undo skeleton's "nowrap" (issue 16) */
   background-color: rgba(0,0,0,0.04);
   border-radius: 3px;
 }


### PR DESCRIPTION
Fixes #16

Undoes Skeleton's odd CSS styling for `<code>`.